### PR TITLE
Fix issue #7 - Lexer error on end of file comment

### DIFF
--- a/Compiler/Sources/boltc/CompilerCore/Lexer/Lexer.swift
+++ b/Compiler/Sources/boltc/CompilerCore/Lexer/Lexer.swift
@@ -164,7 +164,10 @@ extension Lexer {
         while let c = peek(), c.isNewline == false {
             try advance()
         }
-        try advance()
+
+        if scanner.available {
+            try advance()
+        }
     }
 
     private func consumeString() throws -> Token {


### PR DESCRIPTION
Comments that reached the end of the file and were not terminated by a newline character caused an `unexpectedEndOfSource` error to be thrown.