### PR TITLE
Introduce basic Compiler Directives

### DIFF
--- a/Compiler/Sources/boltc/BuildSystem/BuildSystem.swift
+++ b/Compiler/Sources/boltc/BuildSystem/BuildSystem.swift
@@ -31,6 +31,7 @@ class BuildSystem {
     var emitVersion: Bool = false
     var outputPath: String = "program"
     private(set) var libraryPaths: [URL] = []
+    private(set) var linkerFlags: [String] = []
 
     // Only one build system should exist - so its a singleton
     static let main = BuildSystem()
@@ -43,6 +44,10 @@ class BuildSystem {
     func add(libraryPath: String) throws {
         let url = URL(fileURLWithPath: libraryPath)
         libraryPaths.append(url)
+    }
+
+    func specify(linkerFlag: String) {
+        linkerFlags.append(linkerFlag)
     }
 
 }
@@ -188,7 +193,10 @@ extension BuildSystem {
     }
 
     func link(binary: String, objects: [String]) throws {
-        if let result = shell(launchPath: "/usr/bin/ld", arguments: ["-lc", "-o", binary] + objects), result.isEmpty == false {
+        if let result = shell(launchPath: "/usr/bin/ld",
+                              arguments: linkerFlags + ["-o", binary] + objects),
+           result.isEmpty == false
+        {
             print("\(result)")
         }
     }

--- a/Compiler/Sources/boltc/CompilerCore/AST/Expressions.swift
+++ b/Compiler/Sources/boltc/CompilerCore/AST/Expressions.swift
@@ -50,6 +50,9 @@ extension AbstractSyntaxTree {
         case call(identifier: Expression, arguments: [Expression], location: Mark)
         case voidReturn(location: Mark)
         case `return`(Expression, location: Mark)
+
+        // Directives
+        case linkerFlag(flag: String, location: Mark)
     }
 }
 
@@ -73,6 +76,7 @@ extension AbstractSyntaxTree.Expression {
         case let .boundIdentifier(_, location): return location
         case let .voidReturn(location): return location
         case let .return(_, location): return location
+        case let .linkerFlag(_, location): return location
         }
     }
 }

--- a/Compiler/Sources/boltc/CompilerCore/Parser/DirectiveParser.swift
+++ b/Compiler/Sources/boltc/CompilerCore/Parser/DirectiveParser.swift
@@ -1,0 +1,74 @@
+// Copyright (c) 2019 Tom Hancocks
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+struct DirectiveParser: SubParserProtocol {
+
+    static func test(scanner: Scanner<[Token]>) -> Bool {
+        return scanner.test(expected:
+            .symbol(symbol: .at, mark: scanner.location),
+            .identifier(text: "pragma", mark: scanner.location),
+            .symbol(symbol: .leftParen, mark: scanner.location)
+        )
+    }
+
+    static func parse(scanner: Scanner<[Token]>, owner parser: Parser) throws -> AbstractSyntaxTree.Expression {
+        let location = scanner.location
+        
+        // Skip over the first 3 tokens as they should be '@' 'pragma' '('
+        scanner.advance(by: 3)
+
+        // The next part is the domain/namespace that this effects.
+        guard case let .identifier(namespace, _)? = scanner.peek() else {
+            throw Error.parserError(location: scanner.location,
+                                    reason: .unexpectedTokenEncountered(token: scanner.advance()))
+        }
+        scanner.advance()
+
+        // Expect a ','
+        guard case .symbol(.comma, _) = scanner.advance() else {
+            throw Error.parserError(location: scanner.location,
+                                    reason: .unexpectedTokenEncountered(token: scanner.advance()))
+        }
+
+        // The actual flag/information to be given to the namespace.
+        guard case let .string(value, _)? = scanner.peek() else {
+            throw Error.parserError(location: scanner.location,
+                                    reason: .unexpectedTokenEncountered(token: scanner.advance()))
+        }
+        scanner.advance()
+
+        // Expect a final ')'
+        guard case .symbol(.rightParen, _) = scanner.advance() else {
+            throw Error.parserError(location: scanner.location,
+                                    reason: .unexpectedTokenEncountered(token: scanner.advance()))
+        }
+
+        // Construct the appropriate expression for this directive.
+        switch namespace {
+        case "linker":
+            return .linkerFlag(flag: value, location: location)
+
+        default:
+            throw Error.parserError(location: location,
+                                    reason: .unknownCompilerNamespace(name: namespace))
+        }
+    }
+
+}

--- a/Compiler/Sources/boltc/CompilerCore/Parser/Parser.swift
+++ b/Compiler/Sources/boltc/CompilerCore/Parser/Parser.swift
@@ -60,6 +60,9 @@ extension Parser {
         else if test(parser: ImportParser.self) {
             return try parse(parser: ImportParser.self)
         }
+        else if test(parser: DirectiveParser.self) {
+            return try parse(parser: DirectiveParser.self)
+        }
         else {
             guard let token = scanner.peek() else {
                 fatalError("Expected a token to present in the token stream, but found nil.")

--- a/Compiler/Sources/boltc/CompilerCore/Parser/Parser.swift
+++ b/Compiler/Sources/boltc/CompilerCore/Parser/Parser.swift
@@ -41,6 +41,9 @@ extension Parser {
             if case let .module(moduleExpressions, _) = expr {
                 expressions.append(contentsOf: moduleExpressions)
             }
+            else if case let .linkerFlag(flag, _) = expr {
+                BuildSystem.main.specify(linkerFlag: flag)
+            }
             else {
                 expressions.append(expr)
             }

--- a/Compiler/Sources/boltc/Error/ParserError.swift
+++ b/Compiler/Sources/boltc/Error/ParserError.swift
@@ -24,4 +24,5 @@ enum ParserError {
     case unexpectedTokenEncountered(token: Token)
     case expected(token: Token)
     case redefinition(of: AbstractSyntaxTree.Expression, with: AbstractSyntaxTree.Expression)
+    case unknownCompilerNamespace(name: String)
 }

--- a/stdlib/libc.bolt
+++ b/stdlib/libc.bolt
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-@pragma(linker, -lc)
+@pragma(linker, "-lc")
 
 func<None> puts(str: String)
 func<Int> strlen(str: String)

--- a/stdlib/libc.bolt
+++ b/stdlib/libc.bolt
@@ -18,5 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+@pragma(linker, -lc)
+
 func<None> puts(str: String)
 func<Int> strlen(str: String)

--- a/support/plugins/sublime-text/Bolt/Bolt.sublime-syntax
+++ b/support/plugins/sublime-text/Bolt/Bolt.sublime-syntax
@@ -20,6 +20,7 @@ contexts:
     - include: statements
 
   statements:
+    - include: directive
     - include: func_decl
     - include: var_decl
     - include: return
@@ -91,6 +92,13 @@ contexts:
             1: meta.group.bolt
           pop: true
         - include: expressions
+
+  directive:
+    - match: ^(\@(pragma))\s*\((linker)\s*,\s*([^\)]+)\)
+      captures:
+        1: keyword.import.bolt
+        3: entity.name.namespace.bolt
+        4: string.other.bolt
 
 ################################################################################
 


### PR DESCRIPTION
### Purpose
This introduces the basis for compiler directives, and allows source files to specify linker flags that  they will need. This currently is used only by libc.bolt to link against libc.

### Solution
Adds the following grammar into the language:

```bolt
@pragma(linker, "flags")
```